### PR TITLE
feature/merge-pr-workflow-4

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -6,10 +6,6 @@ on:
     types:
       - closed
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   if_merged:
     if: github.event.pull_request.merged == true
@@ -33,4 +29,4 @@ jobs:
           PR_NUM: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
using gh_token instead of github_token in merge-pr workflow